### PR TITLE
fix: resolve open todos and deprecated configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,6 @@ tasks.withType<Kotlin2JsCompile>().configureEach {
   compilerOptions {
     allWarningsAsErrors.set(false)
     progressiveMode.set(true)
-    freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
     target.set("es2015")
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,6 @@
 org.gradle.jvmargs=-Xmx3g -XX:+UseParallelGC -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
-# Incubating features
-org.gradle.unsafe.configuration-cache=true
-org.gradle.unsafe.configuration-cache-problems=warn
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.problems=warn
 kotlin.code.style=official

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 coroutines = "1.11.0"
-datetime = "0.8.0-0.6.x-compat"
+datetime = "0.8.0"
 detekt = "2.0.0-alpha.5"
 gradleVersionsPlugin = "0.52.0"
 jetbrainsCompose = "1.11.1"

--- a/src/jsMain/kotlin/Main.kt
+++ b/src/jsMain/kotlin/Main.kt
@@ -26,14 +26,16 @@ fun main() {
 
     LaunchedEffect(darkMode) {
       localStorage[KEY] = darkMode.toString()
-      console.log("mode set $darkMode")
     }
 
     Style(Style)
     Div({
       classes(if (darkMode) Style.dark else Style.light)
     }) {
-      page()
+      page(
+        isDark = darkMode,
+        toggleDarkMode = { darkMode = !darkMode },
+      )
     }
   }
 }

--- a/src/jsMain/kotlin/de/nilsdruyen/portfolio/WebPage.kt
+++ b/src/jsMain/kotlin/de/nilsdruyen/portfolio/WebPage.kt
@@ -13,22 +13,30 @@ import de.nilsdruyen.portfolio.components.placeholder
 import de.nilsdruyen.portfolio.components.projects
 import de.nilsdruyen.portfolio.components.title
 import de.nilsdruyen.portfolio.components.work
+import de.nilsdruyen.portfolio.ui.Icons
+import de.nilsdruyen.portfolio.ui.Style
+import org.jetbrains.compose.web.css.cssRem
+import org.jetbrains.compose.web.css.marginRight
+import org.jetbrains.compose.web.dom.A
 
 @Composable
-fun page() {
+fun page(isDark: Boolean, toggleDarkMode: () -> Unit) {
   placeholder {
-//    A(
-//      href = "#",
-//      attrs = {
-//        classes(Style.AboutMe.profileLink)
-//        style {
-//          marginRight(1.cssRem)
-//        }
-//        onClick { toggleDarkMode() }
-//      }
-//    ) {
-//      Icons.darkMode(isDark)
-//    }
+    A(
+      href = "#",
+      attrs = {
+        classes(Style.AboutMe.profileLink)
+        style {
+          marginRight(1.cssRem)
+        }
+        onClick {
+          it.preventDefault()
+          toggleDarkMode()
+        }
+      },
+    ) {
+      Icons.darkMode(isDark)
+    }
   }
   title()
   aboutMe()

--- a/src/jsMain/kotlin/de/nilsdruyen/portfolio/components/Work.kt
+++ b/src/jsMain/kotlin/de/nilsdruyen/portfolio/components/Work.kt
@@ -61,7 +61,7 @@ private fun interests() {
     style { paddingBottom(1.cssRem) }
   }) {
     P({
-      classes(Style.Section.title)
+      classes(Style.Section.title, Style.Section.titleOnLight)
       style { fadeIn(200) }
     }) { Text("Interests") }
     Div({ classes(Style.smallMarginBottom, Style.Grid.interestsContainer) }) {

--- a/src/jsMain/kotlin/de/nilsdruyen/portfolio/ui/Colors.kt
+++ b/src/jsMain/kotlin/de/nilsdruyen/portfolio/ui/Colors.kt
@@ -5,7 +5,6 @@
 
 package de.nilsdruyen.portfolio.ui
 
-import de.nilsdruyen.portfolio.ui.Colors.TextGray
 import org.jetbrains.compose.web.css.Color
 
 object Colors {
@@ -13,15 +12,6 @@ object Colors {
   val Blue = "#0583f2".toColor()
   val DarkGrey = "#050608".toColor()
   val TextGray = "#545454".toColor()
-}
-
-object ColorTheme {
-
-  object Light
-  object Dark
-
-  fun Light.title() = TextGray
-  fun Dark.title() = Color.white
 }
 
 fun String.toColor() = Color(this)

--- a/src/jsMain/kotlin/de/nilsdruyen/portfolio/ui/Style.kt
+++ b/src/jsMain/kotlin/de/nilsdruyen/portfolio/ui/Style.kt
@@ -534,13 +534,19 @@ object Style : StyleSheet() {
       fontWeight(500)
       color(sectionTitleColor.value())
     }
+
+    // cards and gradient boxes keep a light background in both themes,
+    // so text on them must not follow the theme variables
+    val titleOnLight by style {
+      color(Colors.DarkGrey)
+    }
     val title2 by style {
       fontSize(20.px)
-      color(titleColor.value())
+      color(Colors.DarkGrey)
     }
     val subtitle by style {
       fontSize(14.px)
-      color(textColor.value())
+      color(Colors.TextGray)
     }
 
     val gradient by style {
@@ -767,6 +773,7 @@ object Style : StyleSheet() {
       fontWeight(500)
       textAlign("center")
       opacity(.5)
+      color(textColor.value())
     }
   }
 }


### PR DESCRIPTION
Sweeps the repo for open TODOs and deprecated configuration/APIs and fixes them:

## Open TODO: dark mode toggle
- `Main.kt` tracked and persisted a `darkMode` state, but the toggle UI was commented out in `WebPage.kt`, so dark mode was unreachable. `page()` now takes `isDark` and a `toggleDarkMode` callback, and the top placeholder renders the existing `Icons.darkMode` icon as a clickable toggle (with `preventDefault()` so the `#` link doesn't scroll).
- Removed the leftover debug `console.log` in the persistence effect.

## Deprecations
- **gradle.properties**: replaced the legacy `org.gradle.unsafe.configuration-cache*` properties with the stable `org.gradle.configuration-cache` / `org.gradle.configuration-cache.problems` keys (stable since Gradle 8.1).
- **build.gradle.kts**: dropped `-opt-in=kotlin.RequiresOptIn`, a redundant no-op since Kotlin 1.7.
- **libs.versions.toml**: moved kotlinx-datetime from `0.8.0-0.6.x-compat` to plain `0.8.0` — the compat artifact only exists to keep the deprecated `kotlinx.datetime.Instant`/`Clock` aliases, and the code already uses `kotlin.time.Clock`.

## Cleanup
- Removed the unused `ColorTheme` object in `Colors.kt`.

`detekt` and `ktlintCheck` pass locally. Full compile verification is left to CI (the sandbox this was authored in cannot reach Google Maven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3y1yQwk4rQB8jVfqCVxoF

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3y1yQwk4rQB8jVfqCVxoF)_