### PR TITLE
chore(deps): align Renovate config with shared cross-repo policy

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,18 +1,25 @@
 {
-  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    'config:best-practices',
-    ':automergePatch',
-    ':automergeDigest',
-    ':automergeBranch',
+    "config:best-practices",
+    ":dependencyDashboard",
+    ":semanticCommits",
   ],
-  baseBranchPatterns: [
-    'develop'
-  ],
-  schedule: [
-    'before 5am on saturday',
-    'before 5am on tuesday'
-  ],
+  baseBranchPatterns: ["develop"],
+  timezone: "Europe/Berlin",
+  schedule: ["before 5am on saturday"],
+  labels: ["dependencies"],
+  platformAutomerge: true,
+
+  // Keep the lockfile fresh and automerge those refreshes too.
+  lockFileMaintenance: {
+    enabled: true,
+    automerge: true,
+    schedule: ["before 5am on saturday"],
+  },
+
+  // Renovate manages these automatically: gradle/libs.versions.toml,
+  // gradle-wrapper.properties, .github/workflows/*.yml and the Dockerfile images.
   customManagers: [
     {
       customType: "regex",
@@ -24,29 +31,30 @@
       datasourceTemplate: "npm",
     },
   ],
+
   packageRules: [
     {
-      groupName: 'Kotlin and KSP',
+      groupName: "Kotlin and KSP",
       matchPackageNames: [
-        '/^org.jetbrains.kotlin/',
-        '/^com.google.devtools.ksp/',
-      ]
-    },
-    {
-      description: 'Automerge non-major updates',
-      matchUpdateTypes: [
-        'patch',
-        'minor'
+        "/^org.jetbrains.kotlin/",
+        "/^com.google.devtools.ksp/",
       ],
-      minimumReleaseAge: '3 days',
-      automerge: true
     },
     {
-      description: 'Automerge major GitHub Actions updates',
-      matchManagers: ['github-actions'],
-      matchUpdateTypes: ['major'],
-      minimumReleaseAge: '3 days',
-      automerge: true
-    }
-  ]
+      // Automerge minor/patch (and pin/digest) once CI passes; majors stay manual.
+      matchUpdateTypes: ["minor", "patch", "pin", "digest"],
+      automerge: true,
+    },
+    {
+      // Bundle all non-major updates into a single PR to cut down on noise.
+      matchUpdateTypes: ["minor", "patch"],
+      groupName: "all non-major dependencies",
+      groupSlug: "all-minor-patch",
+    },
+    {
+      // Major updates require manual approval via the Dependency Dashboard.
+      matchUpdateTypes: ["major"],
+      dependencyDashboardApproval: true,
+    },
+  ],
 }


### PR DESCRIPTION
## Summary
- Switch from branch-based automerge (`:automergeBranch` + friends) to PR-based automerge via `platformAutomerge: true`, matching the mechanism used in coolify-mcp
- Add the Dependency Dashboard explicitly
- Move the schedule from twice-weekly (Sat + Tue) to the shared Saturday 5am (Europe/Berlin) slot used across all homelab repos
- Add `labels: ["dependencies"]` and `lockFileMaintenance`
- Add an explicit `major` package rule requiring Dependency Dashboard approval, replacing the previous `minimumReleaseAge`-based automerge exceptions (patch/minor auto-merged after 3 days, and major GitHub Actions updates auto-merged after 3 days)
- Keep the repo-specific Yarn-resolution `customManagers` regex and Kotlin/KSP grouping unchanged

**Behavior change:** dependency updates now land as visible PRs that auto-merge once CI passes (no release-age buffer), instead of Renovate committing directly to branches. Major GitHub Actions updates no longer auto-merge — all majors now go through the Dependency Dashboard.

This is part of a cross-repo effort to align Renovate config (rules + schedule) across Atlas, cheetah, coolify-mcp, homelab-project-orchestrator, and nilsjr.github.io.

## Test plan
- [x] Validated `.github/renovate.json5` parses as valid JSON5
- [ ] Confirm Renovate picks up the new schedule/config on next run


---
_Generated by [Claude Code](https://claude.ai/code/session_011ba155kHcTJ9kKB5mnq5XA)_